### PR TITLE
Fix the offense we were triggering on Uniswap payback

### DIFF
--- a/ethereum/contracts/Arbrito.sol
+++ b/ethereum/contracts/Arbrito.sol
@@ -26,7 +26,10 @@ contract Arbrito is IUniswapPairCallee {
     uint256 amount1,
     bytes calldata data
   ) external override {
-    (address balancerPoolAddress, address ownerAddress) = abi.decode(data, (address, address));
+    (address balancerPoolAddress, address ownerAddress) = abi.decode(
+      data,
+      (address, address)
+    );
     IBalancerPool balancerPool = IBalancerPool(balancerPoolAddress);
     IUniswapPair uniswapPair = IUniswapPair(msg.sender);
 
@@ -73,7 +76,10 @@ contract Arbrito is IUniswapPairCallee {
     );
 
     require(
-      IERC20(tokenPayback).transfer(ownerAddress, balancerAmountOut - amountPayback),
+      IERC20(tokenPayback).transfer(
+        ownerAddress,
+        balancerAmountOut - amountPayback
+      ),
       "Sender transfer failed"
     );
   }
@@ -84,7 +90,7 @@ contract Arbrito is IUniswapPairCallee {
     uint256 reserveOut
   ) internal pure returns (uint256) {
     uint256 numerator = reserveIn * amountOut * 1000;
-    uint256 denominator = reserveOut * 997;
+    uint256 denominator = (reserveOut - amountOut) * 997;
     return numerator / denominator + 1;
   }
 }

--- a/ethereum/test/Arbrito.js
+++ b/ethereum/test/Arbrito.js
@@ -29,6 +29,8 @@ contract("Arbrito", ([owner]) => {
 
     await token0.mint(uniswap.address, web3.utils.toWei("10", "ether"));
     await token1.mint(uniswap.address, web3.utils.toWei("10", "ether"));
+    await uniswap.refreshReserves();
+
     await token0.mint(balancer.address, web3.utils.toWei("10", "ether"));
     await token1.mint(balancer.address, web3.utils.toWei("30", "ether"));
 
@@ -76,6 +78,8 @@ contract("Arbrito", ([owner]) => {
 
     await token0.mint(uniswap.address, web3.utils.toWei("10", "ether"));
     await token1.mint(uniswap.address, web3.utils.toWei("10", "ether"));
+    await uniswap.refreshReserves();
+
     await token0.mint(balancer.address, web3.utils.toWei("30", "ether"));
     await token1.mint(balancer.address, web3.utils.toWei("10", "ether"));
 
@@ -123,6 +127,8 @@ contract("Arbrito", ([owner]) => {
 
     await token0.mint(uniswap.address, web3.utils.toWei("10", "ether"));
     await token1.mint(uniswap.address, web3.utils.toWei("10", "ether"));
+    await uniswap.refreshReserves();
+
     await token0.mint(balancer.address, web3.utils.toWei("30", "ether"));
     await token1.mint(balancer.address, web3.utils.toWei("10", "ether"));
 

--- a/ethereum/test/external/Uniswap.sol
+++ b/ethereum/test/external/Uniswap.sol
@@ -7,6 +7,8 @@ import "../../contracts/external/IUniswap.sol";
 contract Uniswap is IUniswapPair {
   address token0address;
   address token1address;
+  uint112 reserve0;
+  uint112 reserve1;
 
   constructor(address _token0, address _token1) {
     token0address = _token0;
@@ -31,12 +33,13 @@ contract Uniswap is IUniswapPair {
       uint32
     )
   {
+    return (reserve0, reserve1, 0);
+  }
+
+  function refreshReserves() external {
     address me = address(this);
-    return (
-      uint112(IERC20(token0address).balanceOf(me)),
-      uint112(IERC20(token1address).balanceOf(me)),
-      0
-    );
+    reserve0 = uint112(IERC20(token0address).balanceOf(me));
+    reserve1 = uint112(IERC20(token1address).balanceOf(me));
   }
 
   function swap(
@@ -77,6 +80,9 @@ contract Uniswap is IUniswapPair {
       amount1,
       payload
     );
+
+    reserve0 -= uint112(amount0);
+    reserve1 -= uint112(amount1);
 
     require(tokenLent.balanceOf(me) == tokenLentBalance, "unsupported payback");
 


### PR DESCRIPTION
The thing is that we didn't antecipate the reserves from
uniswap not being deduced of the loan inside the callback.
I mean, it's kind of weird and counter intuitive to have
this behavior but sure.

Closes #47.