### PR TITLE
avoid calling uniswap for tokens

### DIFF
--- a/ethereum/contracts/Arbrito.sol
+++ b/ethereum/contracts/Arbrito.sol
@@ -13,9 +13,11 @@ contract Arbrito is IUniswapPairCallee {
     uint256 amount,
     address uniswapPair,
     address balancerPool,
-    uint256 blockNumber,
+    address uniswapToken0,
+    address uniswapToken1,
     uint256 uniswapReserve0,
-    uint256 uniswapReserve1
+    uint256 uniswapReserve1,
+    uint256 blockNumber
   ) external {
     require(block.number == blockNumber, "Delayed execution");
 
@@ -23,7 +25,15 @@ contract Arbrito is IUniswapPairCallee {
     require(reserve0 == uniswapReserve0, "Reserve0 mismatch");
     require(reserve1 == uniswapReserve1, "Reserve1 mismatch");
 
-    bytes memory payload = abi.encode(balancerPool, msg.sender, reserve0, reserve1);
+    bytes memory payload =
+      abi.encode(
+        balancerPool,
+        msg.sender,
+        uniswapToken0,
+        uniswapToken1,
+        uniswapReserve0,
+        uniswapReserve1
+      );
 
     if (borrow == Borrow.Token0) {
       IUniswapPair(uniswapPair).swap(amount, 0, address(this), payload);
@@ -38,33 +48,30 @@ contract Arbrito is IUniswapPairCallee {
     uint256 amount1,
     bytes calldata data
   ) external override {
-    (address balancerPoolAddress, address ownerAddress, uint256 reserve0, uint256 reserve1) =
-      abi.decode(data, (address, address, uint256, uint256));
-
-    IUniswapPair uniswapPair = IUniswapPair(msg.sender);
+    (
+      address balancerPoolAddress,
+      address ownerAddress,
+      address token0,
+      address token1,
+      uint256 reserve0,
+      uint256 reserve1
+    ) = abi.decode(data, (address, address, address, address, uint256, uint256));
 
     uint256 amountTrade;
     uint256 amountPayback;
-
-    uint256 reservePayback;
-    uint256 reserveTrade;
 
     address tokenPayback;
     address tokenTrade;
 
     if (amount0 != 0) {
-      (reserveTrade, reservePayback) = (reserve0, reserve1);
-      tokenPayback = uniswapPair.token1();
-      tokenTrade = uniswapPair.token0();
       amountTrade = amount0;
+      (tokenTrade, tokenPayback) = (token0, token1);
+      amountPayback = calculateUniswapPayback(amountTrade, reserve1, reserve0);
     } else {
-      (reservePayback, reserveTrade) = (reserve0, reserve1);
-      tokenPayback = uniswapPair.token0();
-      tokenTrade = uniswapPair.token1();
       amountTrade = amount1;
+      (tokenPayback, tokenTrade) = (token0, token1);
+      amountPayback = calculateUniswapPayback(amountTrade, reserve0, reserve1);
     }
-
-    amountPayback = calculateUniswapPayback(amountTrade, reservePayback, reserveTrade);
 
     IERC20(tokenTrade).approve(balancerPoolAddress, amountTrade);
 

--- a/ethereum/contracts/external/IUniswap.sol
+++ b/ethereum/contracts/external/IUniswap.sol
@@ -11,10 +11,6 @@ interface IUniswapPairCallee {
 }
 
 interface IUniswapPair {
-  function token0() external view returns (address);
-
-  function token1() external view returns (address);
-
   function getReserves()
     external
     view

--- a/ethereum/test/Arbrito.ts
+++ b/ethereum/test/Arbrito.ts
@@ -33,14 +33,16 @@ contract("Arbrito", ([owner]) => {
     await token0.mint(balancer.address, web3.utils.toWei("10", "ether"));
     await token1.mint(balancer.address, web3.utils.toWei("30", "ether"));
 
-    await arbrito.perform(
+    const tx = await arbrito.perform(
       0,
       web3.utils.toWei("1", "ether"),
       uniswap.address,
       balancer.address,
-      (await web3.eth.getBlockNumber()) + 1,
+      token0.address,
+      token1.address,
       uniswapReserve0,
-      uniswapReserve1
+      uniswapReserve1,
+      (await web3.eth.getBlockNumber()) + 1
     );
 
     expect((await token0.balanceOf(uniswap.address)).toString()).equal(
@@ -85,9 +87,11 @@ contract("Arbrito", ([owner]) => {
       web3.utils.toWei("1", "ether"),
       uniswap.address,
       balancer.address,
-      (await web3.eth.getBlockNumber()) + 1,
+      token0.address,
+      token1.address,
       uniswapReserve0,
-      uniswapReserve1
+      uniswapReserve1,
+      (await web3.eth.getBlockNumber()) + 1
     );
 
     expect((await token1.balanceOf(uniswap.address)).toString()).equal(
@@ -134,9 +138,11 @@ contract("Arbrito", ([owner]) => {
         web3.utils.toWei("1", "ether"),
         uniswap.address,
         balancer.address,
-        (await web3.eth.getBlockNumber()) + 1,
+        token0.address,
+        token1.address,
         uniswapReserve0,
-        uniswapReserve1
+        uniswapReserve1,
+        (await web3.eth.getBlockNumber()) + 1
       );
     } catch (e) {
       error = e;
@@ -146,18 +152,20 @@ contract("Arbrito", ([owner]) => {
   });
 
   it("reverts when the block is mined in delayed block", async () => {
-    const [arbrito] = await deployContracts();
+    const [arbrito, uniswap, balancer, token0, token1] = await deployContracts();
 
     let error;
     try {
       await arbrito.perform(
         1,
         web3.utils.toWei("6", "ether"),
-        "0xdfc14d2af169b0d36c4eff567ada9b2e0cae044f",
-        "0x7c90a3cd7ec80dd2f633ed562480abbeed3be546",
-        await web3.eth.getBlockNumber(),
+        uniswap.address,
+        balancer.address,
+        token0.address,
+        token1.address,
         0,
-        0
+        0,
+        await web3.eth.getBlockNumber()
       );
     } catch (e) {
       error = e;
@@ -167,7 +175,7 @@ contract("Arbrito", ([owner]) => {
   });
 
   it("reverts if the uniswap reserves are different from expected", async () => {
-    const [arbrito, uniswap, balancer] = await deployContracts();
+    const [arbrito, uniswap, balancer, token0, token1] = await deployContracts();
     let count = 0;
 
     try {
@@ -176,9 +184,11 @@ contract("Arbrito", ([owner]) => {
         web3.utils.toWei("6", "ether"),
         uniswap.address,
         balancer.address,
-        (await web3.eth.getBlockNumber()) + 1,
+        token0.address,
+        token1.address,
         1,
-        0
+        0,
+        (await web3.eth.getBlockNumber()) + 1
       );
     } catch (e) {
       expect(e).match(/Reserve0 mismatch/);
@@ -191,9 +201,11 @@ contract("Arbrito", ([owner]) => {
         web3.utils.toWei("6", "ether"),
         uniswap.address,
         balancer.address,
-        (await web3.eth.getBlockNumber()) + 1,
+        token0.address,
+        token1.address,
         0,
-        1
+        1,
+        (await web3.eth.getBlockNumber()) + 1
       );
     } catch (e) {
       expect(e).match(/Reserve1 mismatch/);
@@ -214,6 +226,8 @@ contract("Arbrito", ([owner]) => {
       web3.utils.toWei("6", "ether"),
       "0xdfc14d2af169b0d36c4eff567ada9b2e0cae044f",
       "0x7c90a3cd7ec80dd2f633ed562480abbeed3be546",
+      "0x7Fc66500c84A76Ad7e9c93437bFc5Ac33E2DDaE9",
+      "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
       (await web3.eth.getBlockNumber()) + 1
     );
 

--- a/ethereum/test/Arbrito.ts
+++ b/ethereum/test/Arbrito.ts
@@ -34,7 +34,7 @@ contract("Arbrito", ([owner]) => {
     await token1.mint(balancer.address, web3.utils.toWei("30", "ether"));
 
     await arbrito.perform(
-      true,
+      0,
       web3.utils.toWei("1", "ether"),
       uniswap.address,
       balancer.address,
@@ -81,7 +81,7 @@ contract("Arbrito", ([owner]) => {
     await token1.mint(balancer.address, web3.utils.toWei("10", "ether"));
 
     await arbrito.perform(
-      false,
+      1,
       web3.utils.toWei("1", "ether"),
       uniswap.address,
       balancer.address,
@@ -130,7 +130,7 @@ contract("Arbrito", ([owner]) => {
     let error;
     try {
       await arbrito.perform(
-        true,
+        0,
         web3.utils.toWei("1", "ether"),
         uniswap.address,
         balancer.address,
@@ -151,7 +151,7 @@ contract("Arbrito", ([owner]) => {
     let error;
     try {
       await arbrito.perform(
-        false,
+        1,
         web3.utils.toWei("6", "ether"),
         "0xdfc14d2af169b0d36c4eff567ada9b2e0cae044f",
         "0x7c90a3cd7ec80dd2f633ed562480abbeed3be546",
@@ -172,7 +172,7 @@ contract("Arbrito", ([owner]) => {
 
     try {
       await arbrito.perform(
-        false,
+        1,
         web3.utils.toWei("6", "ether"),
         uniswap.address,
         balancer.address,
@@ -187,7 +187,7 @@ contract("Arbrito", ([owner]) => {
 
     try {
       await arbrito.perform(
-        false,
+        1,
         web3.utils.toWei("6", "ether"),
         uniswap.address,
         balancer.address,
@@ -210,7 +210,7 @@ contract("Arbrito", ([owner]) => {
     const weth = await ERC20.at("0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2");
 
     await arbrito.perform(
-      false,
+      1,
       web3.utils.toWei("6", "ether"),
       "0xdfc14d2af169b0d36c4eff567ada9b2e0cae044f",
       "0x7c90a3cd7ec80dd2f633ed562480abbeed3be546",

--- a/ethereum/test/external/Uniswap.sol
+++ b/ethereum/test/external/Uniswap.sol
@@ -15,14 +15,6 @@ contract Uniswap is IUniswapPair {
     token1address = _token1;
   }
 
-  function token0() external view override returns (address) {
-    return token0address;
-  }
-
-  function token1() external view override returns (address) {
-    return token1address;
-  }
-
   function getReserves()
     external
     view


### PR DESCRIPTION
- Replace direction with enum for clarity
- Add tokens to contract parameter to avoid calling uniswap for them
Closes #72.