### PR TITLE
Avoid multiple approve requests

### DIFF
--- a/ethereum/contracts/Arbrito.sol
+++ b/ethereum/contracts/Arbrito.sol
@@ -51,7 +51,7 @@ contract Arbrito is IUniswapPairCallee {
   }
 
   function uniswapV2Call(
-    address, // sender
+    address sender,
     uint256 amount0,
     uint256 amount1,
     bytes calldata data
@@ -81,7 +81,7 @@ contract Arbrito is IUniswapPairCallee {
       amountPayback = calculateUniswapPayback(amountTrade, reserve0, reserve1);
     }
 
-    IERC20(tokenTrade).approve(balancerPoolAddress, amountTrade);
+    allow(sender, balancerPoolAddress, tokenTrade, amountTrade);
 
     (uint256 balancerAmountOut, ) =
       IBalancerPool(balancerPoolAddress).swapExactAmountIn(
@@ -98,6 +98,17 @@ contract Arbrito is IUniswapPairCallee {
       IERC20(tokenPayback).transfer(ownerAddress, balancerAmountOut - amountPayback),
       "Sender transfer failed"
     );
+  }
+
+  function allow(
+    address sender,
+    address balancer,
+    address tokenTrade,
+    uint256 amountTrade
+  ) internal {
+    if (IERC20(tokenTrade).allowance(sender, balancer) < amountTrade) {
+      IERC20(tokenTrade).approve(balancer, uint256(-1));
+    }
   }
 
   function calculateUniswapPayback(

--- a/ethereum/contracts/external/IERC20.sol
+++ b/ethereum/contracts/external/IERC20.sol
@@ -5,4 +5,6 @@ interface IERC20 {
   function approve(address spender, uint256 amount) external returns (bool);
 
   function transfer(address recipient, uint256 amount) external returns (bool);
+
+  function allowance(address owner, address spender) external view returns (uint256);
 }


### PR DESCRIPTION
Just like the relationship between me and my family,
asking for approval too much might imply in some confidence
risks and gas penalties. Thus, we want to ask for it as few
times as possible.

Closes #106.
